### PR TITLE
Add slice-aware training utilities and MoE router logging

### DIFF
--- a/collators.py
+++ b/collators.py
@@ -1,0 +1,80 @@
+"""Custom data collators that are aware of slice metadata."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Dict, Iterable, List
+
+import torch
+from torch.nn.utils.rnn import pad_sequence
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+
+class SliceCollator:
+    """Collate samples grouped by their slice metadata.
+
+    The collator keeps together samples that share the same ``slice`` tag so
+    that each micro-batch emphasises a particular data regime. This makes it
+    easier for the MoE router to specialise experts early in training.
+    """
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        *,
+        capacity_factor: float = 1.2,
+        max_seq_len: int = 512,
+        micro_batch_size: int = 8,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.capacity_factor = capacity_factor
+        self.max_seq_len = max_seq_len
+        self.micro_batch_size = micro_batch_size
+
+    def _bucket_by_slice(self, examples: Iterable[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+        buckets: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for example in examples:
+            slice_id = example.get("slice", "default")
+            buckets[slice_id].append(example)
+        return buckets
+
+    def __call__(self, examples: List[Dict[str, Any]]) -> Dict[str, Any]:
+        slice_buckets = self._bucket_by_slice(examples)
+
+        input_ids: List[torch.Tensor] = []
+        attention_masks: List[torch.Tensor] = []
+        slice_ids: List[str] = []
+
+        for slice_id, bucket in slice_buckets.items():
+            texts = [example["text"] for example in bucket]
+            encodings = self.tokenizer(
+                texts,
+                truncation=True,
+                padding=False,
+                max_length=self.max_seq_len,
+                return_tensors="pt",
+            )
+            input_ids.extend(encodings["input_ids"])
+            attention_masks.extend(encodings["attention_mask"])
+            slice_ids.extend([slice_id] * len(texts))
+
+        if not input_ids:
+            raise ValueError("SliceCollator received an empty batch")
+
+        input_ids_tensor = pad_sequence(
+            input_ids,
+            batch_first=True,
+            padding_value=self.tokenizer.pad_token_id,
+        )
+        attention_mask_tensor = pad_sequence(
+            attention_masks,
+            batch_first=True,
+            padding_value=0,
+        )
+
+        return {
+            "input_ids": input_ids_tensor,
+            "attention_mask": attention_mask_tensor,
+            "slice_ids": slice_ids,
+            "slice_count": Counter(slice_ids),
+        }

--- a/curriculum.py
+++ b/curriculum.py
@@ -1,0 +1,100 @@
+"""Curriculum sampling utilities to gradually adjust slice ratios."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import torch
+from transformers import TrainerCallback
+from transformers.trainer_callback import TrainerControl, TrainerState
+from transformers.training_args import TrainingArguments
+
+
+@dataclass
+class CurriculumPhase:
+    """A single phase in the curriculum schedule."""
+
+    threshold: int
+    weights: Dict[str, float]
+
+
+class CurriculumSampler:
+    """Maintain slice sampling weights that evolve during training."""
+
+    def __init__(
+        self,
+        dataset,
+        phases: Sequence[Tuple[int, Dict[str, float]]],
+        *,
+        current_step: int = 0,
+        default_weight: float = 1.0,
+    ) -> None:
+        if not phases:
+            raise ValueError("CurriculumSampler requires at least one phase")
+        self.dataset = dataset
+        self.phases: List[CurriculumPhase] = [CurriculumPhase(*phase) for phase in phases]
+        self.phases.sort(key=lambda phase: phase.threshold)
+        self.current_step = int(current_step)
+        self.default_weight = float(default_weight)
+
+    def set_step(self, step: int) -> None:
+        self.current_step = int(step)
+
+    def _current_phase_weights(self) -> Dict[str, float]:
+        for phase in self.phases:
+            if self.current_step <= phase.threshold:
+                return phase.weights
+        return self.phases[-1].weights
+
+    def get_weights(self) -> torch.Tensor:
+        num_examples = len(self.dataset)
+        if num_examples == 0:
+            return torch.zeros(0, dtype=torch.double)
+
+        weights_map = self._current_phase_weights()
+        if hasattr(self.dataset, "column_names") and "slice" in self.dataset.column_names:
+            slices: Iterable[str] = self.dataset["slice"]
+        else:
+            slices = ["default"] * num_examples
+
+        weights = [float(weights_map.get(slice_id, self.default_weight)) for slice_id in slices]
+        tensor = torch.tensor(weights, dtype=torch.double)
+        tensor = tensor.clamp_min(1e-6)
+        return tensor
+
+
+class CurriculumCallback(TrainerCallback):
+    """Update the dataloader sampler as the curriculum progresses."""
+
+    def __init__(self, sampler: CurriculumSampler) -> None:
+        self.sampler = sampler
+
+    def on_step_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        self.sampler.set_step(state.global_step)
+        train_dataloader = kwargs.get("train_dataloader")
+        if train_dataloader is None:
+            return control
+
+        data_sampler = getattr(train_dataloader, "sampler", None)
+        if data_sampler is None or not hasattr(data_sampler, "weights"):
+            return control
+
+        weights = self.sampler.get_weights()
+        if weights.numel() == 0:
+            return control
+
+        sampler_weights = data_sampler.weights
+        dtype = sampler_weights.dtype if torch.is_tensor(sampler_weights) else torch.double
+        device = sampler_weights.device if torch.is_tensor(sampler_weights) else torch.device("cpu")
+        data_sampler.weights = weights.to(device=device, dtype=dtype)
+        if hasattr(data_sampler, "num_samples"):
+            data_sampler.num_samples = len(weights)
+
+        return control

--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,25 @@
+"""Utility helpers for dataset preprocessing and slice annotations."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def slice_by_metadata(example: Dict[str, str]) -> Dict[str, str]:
+    """Annotate an example with a coarse language slice label.
+
+    The heuristic matches the behaviour described in the task instructions and
+    is intentionally lightweight so it can run during dataset mapping without
+    additional dependencies.
+    """
+
+    text = example.get("text", "")
+    if "def " in text or "class " in text:
+        example["slice"] = "code"
+    elif any(ch in text for ch in "。！？"):
+        example["slice"] = "zh"
+    elif text.isascii():
+        example["slice"] = "en"
+    else:
+        example["slice"] = "general"
+    return example

--- a/example_train_tiny_with_slices.py
+++ b/example_train_tiny_with_slices.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Example script demonstrating slice-aware fine-tuning for Qwen3-MoE."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import torch
+from datasets import Dataset, DatasetDict
+from peft import LoraConfig, get_peft_model
+from torch.utils.data import WeightedRandomSampler
+from transformers import AutoTokenizer
+from transformers.utils import has_length
+from trl import SFTConfig, SFTTrainer
+
+from collators import SliceCollator
+from curriculum import CurriculumCallback, CurriculumSampler
+from data_utils import slice_by_metadata
+from losses import compute_loss
+from qwen3_moe_fused.fast_lora import patch_Qwen3MoeFusedSparseMoeBlock_forward
+from qwen3_moe_fused.lora import patch_lora_config
+from qwen3_moe_fused.modular_qwen3_moe_fused import Qwen3MoeFusedForCausalLM
+from qwen3_moe_fused.quantize.quantizer import patch_bnb_quantizer
+
+
+os.environ.setdefault("TRITON_PRINT_AUTOTUNING", "1")
+
+
+class SliceSFTTrainer(SFTTrainer):
+    """SFTTrainer variant that injects curriculum-aware sampling."""
+
+    def __init__(self, *args, curriculum_sampler: Optional[CurriculumSampler] = None, **kwargs):
+        self.curriculum_sampler = curriculum_sampler
+        super().__init__(*args, **kwargs)
+
+    def _get_train_sampler(self, train_dataset=None):
+        if self.curriculum_sampler is None:
+            return super()._get_train_sampler(train_dataset)
+
+        dataset = train_dataset if train_dataset is not None else self.train_dataset
+        if dataset is None or not has_length(dataset):
+            return None
+
+        weights = self.curriculum_sampler.get_weights()
+        if weights.numel() == 0:
+            return super()._get_train_sampler(train_dataset)
+
+        return WeightedRandomSampler(weights, num_samples=len(weights), replacement=True)
+
+
+def build_tiny_dataset() -> DatasetDict:
+    samples = [
+        {"text": "Hello world! This is a tiny English sentence."},
+        {"text": "def add(a, b):\n    return a + b"},
+        {"text": "你好，世界。这是一段中文样本。"},
+        {"text": "class Greeter:\n    def greet(self):\n        print('hi')"},
+        {"text": "纯中文示例，用于验证切片策略。"},
+        {"text": "The quick brown fox jumps over the lazy dog."},
+        {"text": "import math\nmath.sqrt(2)"},
+        {"text": "Mixed language 示例 with ASCII and 非ASCII."},
+        {"text": "Once upon a time in a tiny dataset."},
+        {"text": "这是一个非常简短的中文描述。"},
+    ]
+    dataset = Dataset.from_list(samples)
+    dataset = dataset.shuffle(seed=42)
+    dataset = dataset.train_test_split(test_size=0.2, seed=42)
+    dataset = DatasetDict(
+        train=dataset["train"].map(slice_by_metadata),
+        validation=dataset["test"].map(slice_by_metadata),
+    )
+    return dataset
+
+
+def main():
+    patch_bnb_quantizer()
+    patch_lora_config()
+    patch_Qwen3MoeFusedSparseMoeBlock_forward()
+
+    model_dir = "./pretrained/qwen-moe-tiny-lm"
+
+    model = Qwen3MoeFusedForCausalLM.from_pretrained(model_dir)
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    lora_config = LoraConfig(
+        target_modules=[
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ],
+        rank_pattern={
+            "q_proj": 16,
+            "k_proj": 16,
+            "v_proj": 16,
+            "o_proj": 16,
+            "gate": 16,
+            "gate_proj": 4,
+            "up_proj": 4,
+            "down_proj": 4,
+        },
+        lora_alpha=1,
+        use_rslora=True,
+    )
+    model = get_peft_model(model, lora_config)
+
+    dataset = build_tiny_dataset()
+
+    collator = SliceCollator(tokenizer, max_seq_len=256, micro_batch_size=4)
+
+    phases = [
+        (1000, {"code": 0.6, "zh": 0.2, "en": 0.2}),
+        (5000, {"code": 0.4, "zh": 0.3, "en": 0.3}),
+        (10000, {"code": 0.3, "zh": 0.3, "en": 0.4}),
+    ]
+    curriculum_sampler = CurriculumSampler(dataset["train"], phases)
+    curriculum_callback = CurriculumCallback(curriculum_sampler)
+
+    sft_config = SFTConfig(
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=1,
+        learning_rate=5e-3,
+        weight_decay=1e-2,
+        num_train_epochs=1,
+        logging_steps=1,
+        save_steps=5,
+        bf16=torch.cuda.is_available(),
+        optim="adamw_torch",
+        dataset_text_field="text",
+        dataset_num_proc=1,
+        report_to="none",
+    )
+
+    trainer = SliceSFTTrainer(
+        model=model,
+        processing_class=tokenizer,
+        train_dataset=dataset["train"],
+        eval_dataset=dataset["validation"],
+        args=sft_config,
+        data_collator=collator,
+        compute_loss_func=compute_loss,
+        callbacks=[curriculum_callback],
+        curriculum_sampler=curriculum_sampler,
+    )
+
+    trainer_stats = trainer.train()
+    print("trainer_stats")
+    print(trainer_stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/losses.py
+++ b/losses.py
@@ -1,0 +1,100 @@
+"""Auxiliary loss helpers for mixture-of-experts regularisation."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+import torch
+import torch.nn.functional as F
+
+
+def balance_loss(router_logits: torch.Tensor) -> torch.Tensor:
+    """Encourage a uniform expert load distribution."""
+
+    probs = F.softmax(router_logits, dim=-1)
+    expert_load = probs.sum(0) / probs.sum()
+    target = torch.full_like(expert_load, 1.0 / expert_load.size(0))
+    return F.mse_loss(expert_load, target)
+
+
+def contrastive_loss(router_logits: torch.Tensor, slice_ids: Sequence[str]) -> torch.Tensor:
+    """Pull together router decisions for the same slice and push apart others."""
+
+    probs = F.softmax(router_logits, dim=-1)
+    sim = torch.matmul(probs, probs.T)
+    loss = torch.zeros((), dtype=probs.dtype, device=probs.device)
+    count = 0
+    for i in range(len(slice_ids)):
+        for j in range(i + 1, len(slice_ids)):
+            if slice_ids[i] == slice_ids[j]:
+                loss = loss + (1 - sim[i, j]) ** 2
+            else:
+                loss = loss + (sim[i, j]) ** 2
+            count += 1
+    if count == 0:
+        return torch.zeros((), dtype=probs.dtype, device=probs.device)
+    return loss / count
+
+
+def _reshape_router_logits(
+    router_logits: torch.Tensor,
+    batch_size: int,
+    seq_len: int,
+) -> torch.Tensor:
+    return router_logits.view(batch_size, seq_len, -1)
+
+
+def _aggregate_router_logits(
+    router_logits: Iterable[torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    attention_mask: torch.Tensor | None,
+) -> torch.Tensor | None:
+    tensors: List[torch.Tensor] = []
+    for layer_router in router_logits:
+        if layer_router is None:
+            continue
+        tensors.append(_reshape_router_logits(layer_router, batch_size, seq_len))
+
+    if not tensors:
+        return None
+
+    stacked = torch.stack(tensors, dim=0)  # (num_layers, batch, seq, experts)
+    stacked = stacked.permute(1, 0, 2, 3)  # (batch, num_layers, seq, experts)
+
+    if attention_mask is not None:
+        mask = attention_mask.to(stacked.device).unsqueeze(1).unsqueeze(-1)
+        token_totals = mask.sum(dim=2, keepdim=True).clamp_min(1.0)
+        stacked = (stacked * mask).sum(dim=2) / token_totals
+    else:
+        stacked = stacked.mean(dim=2)
+
+    return stacked.mean(dim=1)  # (batch, experts)
+
+
+def compute_loss(model, inputs, return_outputs: bool = False):
+    outputs = model(
+        input_ids=inputs["input_ids"],
+        attention_mask=inputs.get("attention_mask"),
+        labels=inputs["input_ids"],
+        output_router_logits=True,
+    )
+    main_loss = outputs["loss"]
+    router_logits = outputs.get("router_logits")
+    slice_ids = inputs.get("slice_ids")
+    attention_mask = inputs.get("attention_mask")
+
+    aux_loss = torch.zeros((), dtype=main_loss.dtype, device=main_loss.device)
+    if router_logits is not None and slice_ids is not None:
+        batch_size, seq_len = inputs["input_ids"].shape[:2]
+        if isinstance(router_logits, torch.Tensor):
+            router_iterable = (router_logits,)
+        else:
+            router_iterable = tuple(router_logits)
+        aggregated = _aggregate_router_logits(router_iterable, batch_size, seq_len, attention_mask)
+        if aggregated is not None and aggregated.size(0) == len(slice_ids):
+            aux_loss = aux_loss + 0.01 * balance_loss(aggregated)
+            aux_loss = aux_loss + 0.01 * contrastive_loss(aggregated, slice_ids)
+
+    total_loss = main_loss + aux_loss
+    return (total_loss, outputs) if return_outputs else total_loss


### PR DESCRIPTION
## Summary
- annotate datasets with slice metadata and batch them with a slice-aware collator
- add auxiliary router losses, curriculum sampling utilities, and expose router logits from the fused model
- provide an end-to-end tiny training example that wires the new components into SFTTrainer

## Testing
- python -m compileall data_utils.py collators.py losses.py curriculum.py example_train_tiny_with_slices.py qwen3_moe_fused/modular_qwen3_moe_fused.py


------
https://chatgpt.com/codex/tasks/task_e_68ceb5de495c8327b12379f5fb84af56