### PR TITLE
Add unified preprocessing for SFT trainer datasets

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -2,24 +2,60 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 
 
-def slice_by_metadata(example: Dict[str, str]) -> Dict[str, str]:
-    """Annotate an example with a coarse language slice label.
+def slice_by_metadata(example: Dict) -> Dict:
+    """Assign a slice label based on the structure of the example."""
 
-    The heuristic matches the behaviour described in the task instructions and
-    is intentionally lightweight so it can run during dataset mapping without
-    additional dependencies.
-    """
-
-    text = example.get("text", "")
-    if "def " in text or "class " in text:
-        example["slice"] = "code"
-    elif any(ch in text for ch in "。！？"):
-        example["slice"] = "zh"
-    elif text.isascii():
-        example["slice"] = "en"
+    if "messages" in example:
+        example["slice"] = "agent"
+    elif "text" in example and "label" in example:
+        example["slice"] = "classification"
     else:
         example["slice"] = "general"
     return example
+
+
+def format_example(example: Dict) -> Dict:
+    """Normalise heterogeneous samples into prompt/target pairs."""
+
+    if example.get("slice") == "classification":
+        text = example["text"]
+        label = str(example["label"])
+        prompt = "分类任务: 请判断以下评论的情感。\n\n评论: {text}\n\n答案:".format(text=text)
+        target = label
+    elif example.get("slice") == "agent":
+        messages = example.get("messages", [])
+        conv = ""
+        for message in messages:
+            role = "用户" if message.get("role") == "user" else "助手"
+            content = message.get("content", "")
+            conv += f"{role}: {content}\n" if content else f"{role}: \n"
+        system = example.get("system", "")
+        prompt = f"{system}\n{conv}" if system else conv
+        if messages and messages[-1].get("role") == "assistant" and messages[-1].get("content"):
+            target = messages[-1]["content"]
+        else:
+            target = ""
+    else:
+        prompt = example.get("text", "")
+        target = ""
+
+    return {"prompt": prompt, "target": target}
+
+
+def tokenize_fn(examples: Dict[str, List[str]], tokenizer, max_length: int = 512):
+    """Tokenize prompt/target pairs for supervised fine-tuning."""
+
+    prompts: List[str] = examples["prompt"]
+    targets: List[str] = examples["target"]
+    texts = [prompt + target for prompt, target in zip(prompts, targets)]
+    encodings = tokenizer(
+        texts,
+        truncation=True,
+        padding="max_length",
+        max_length=max_length,
+    )
+    encodings["labels"] = encodings["input_ids"].copy()
+    return encodings

--- a/example_train_30b_a3b_unsloth_slices.py
+++ b/example_train_30b_a3b_unsloth_slices.py
@@ -8,15 +8,14 @@ from typing import Optional
 
 from datasets import load_dataset
 from torch.utils.data import WeightedRandomSampler
-from transformers import TrainingArguments
+from transformers import AutoTokenizer, DataCollatorForLanguageModeling, TrainingArguments
 from transformers.utils import has_length
 from trl import SFTTrainer
 
 from unsloth import FastLanguageModel
 
-from collators import SliceCollator
 from curriculum import CurriculumCallback, CurriculumSampler
-from data_utils import slice_by_metadata
+from data_utils import format_example, slice_by_metadata, tokenize_fn
 from losses import compute_loss
 from qwen3_moe_fused.fast_lora import patch_Qwen3MoeFusedSparseMoeBlock_forward
 from qwen3_moe_fused.lora import patch_lora_config
@@ -65,22 +64,48 @@ def main() -> None:
     patch_Qwen3MoeFusedSparseMoeBlock_forward()
 
     # === Step 2. 数据准备 ===
-    dataset = load_dataset("stanfordnlp/imdb")
-    dataset = dataset.map(slice_by_metadata)
+    imdb = load_dataset("stanfordnlp/imdb")
+    agent = load_dataset("json", data_files="agent.json")
+
+    imdb = imdb.map(slice_by_metadata)
+    agent = agent.map(slice_by_metadata)
+
+    imdb = imdb.map(format_example)
+    agent = agent.map(format_example)
+
+    columns_to_keep = {"prompt", "target", "slice"}
+    imdb = imdb.remove_columns([col for col in imdb["train"].column_names if col not in columns_to_keep])
+    agent = agent.remove_columns([col for col in agent["train"].column_names if col not in columns_to_keep])
+
+    train_dataset = imdb["train"].concatenate(agent["train"])
+    eval_dataset = imdb.get("test")
 
     model_id = "bash99/Qwen3-30B-A3B-Instruct-2507-fused-bnb-4bit"
-    tokenizer = FastLanguageModel.get_tokenizer(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
-    collator = SliceCollator(tokenizer)
+    tokenized_train = train_dataset.map(tokenize_fn, fn_kwargs={"tokenizer": tokenizer}, batched=True)
+    if eval_dataset is not None:
+        tokenized_eval = eval_dataset.map(tokenize_fn, fn_kwargs={"tokenizer": tokenizer}, batched=True)
+    else:
+        tokenized_eval = None
+
+    data_collator_lm = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    def data_collator(features):
+        filtered = [
+            {key: value for key, value in feature.items() if key in {"input_ids", "attention_mask", "labels"}}
+            for feature in features
+        ]
+        return data_collator_lm(filtered)
 
     phases = [
-        (1000, {"en": 0.5, "zh": 0.3, "code": 0.2}),
-        (5000, {"en": 0.4, "zh": 0.3, "code": 0.3}),
-        (10000, {"en": 0.3, "zh": 0.3, "code": 0.4}),
+        (1000, {"classification": 0.5, "agent": 0.5}),
+        (5000, {"classification": 0.4, "agent": 0.6}),
+        (10000, {"classification": 0.3, "agent": 0.7}),
     ]
-    curriculum_sampler = CurriculumSampler(dataset["train"], phases)
+    curriculum_sampler = CurriculumSampler(tokenized_train, phases)
     curriculum_callback = CurriculumCallback(curriculum_sampler)
 
     # === Step 3. 加载模型 ===
@@ -132,10 +157,10 @@ def main() -> None:
     trainer = SliceSFTTrainer(
         model=model,
         processing_class=tokenizer,
-        train_dataset=dataset["train"],
-        eval_dataset=dataset.get("test"),
+        train_dataset=tokenized_train,
+        eval_dataset=tokenized_eval,
         args=training_args,
-        data_collator=collator,
+        data_collator=data_collator,
         compute_loss_func=compute_loss,
         callbacks=[curriculum_callback],
         curriculum_sampler=curriculum_sampler,


### PR DESCRIPTION
## Summary
- add metadata-based slice labels and prompt/target formatting helpers for heterogeneous inputs
- provide a tokenization helper that produces language-model-style inputs for SFT training
- update the Qwen3 Unsloth example to combine IMDB and agent data, preprocess with the new helpers, and feed the tokenized set to SFTTrainer

## Testing
- python -m compileall data_utils.py example_train_30b_a3b_unsloth_slices.py


------
https://chatgpt.com/codex/tasks/task_e_68cedc37d9b08327beb8618ac2be2af6